### PR TITLE
Solving issue with endlines (CLRF vs LF) in Linux

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,11 @@
 # Declare files that will always have CRLF line endings on checkout.
 *.py text eol=crlf
 *.json text eol=crlf
+*.txt text eol= crlf
+*.html text eol=crlf
+*.css text eol=crlf
+*.js text eol=crlf
+*.md text eol=crlf
 
 # Denote all files that are truly binary and should not be modified.
 *.db binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.py text eol=crlf
+*.json text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.db binary
+


### PR DESCRIPTION
As this project is mostly written in Windows systems, when working in Linux, we face issues tackling the end-of-line (CLRF vs LF).  To solve these issues, .gitattributes will handle this specific repository (without changing the global configurations on each system).